### PR TITLE
docs: fill in 05_gitops.md with ArgoCD App-of-Apps details

### DIFF
--- a/docs/05_gitops.md
+++ b/docs/05_gitops.md
@@ -1,25 +1,172 @@
 # GitOps — ArgoCD
 
-> To be updated when Phase 5 is reached.
+Covers Phase 5: installing ArgoCD and bootstrapping the App-of-Apps that manages all cluster workloads. The cluster must already be running with Cilium installed (`04_kubernetes.md`).
+
+Run from `homekube-main/ansible/` on darth.
+
+---
+
+## Overview
+
+The cluster uses ArgoCD's **App-of-Apps** pattern: a single root Application (`root-app`) in the `argocd` namespace watches the `jangroth/homekube-apps` Git repository. Every subdirectory under `applications/` is itself an ArgoCD Application — ArgoCD discovers and deploys them automatically. Changes pushed to `homekube-apps` are synced continuously; no manual `kubectl apply` is needed after initial bootstrap.
+
+```
+homekube-main (Ansible bootstrap)
+  └── root-app (ArgoCD Application)
+        └── homekube-apps/applications/
+              ├── wave-00-init/   (sync-wave: "-1")
+              └── wave-01-apps/   (sync-wave: "1")
+```
+
+---
 
 ## Deploy ArgoCD
 
-```shell
-ansible-playbook 06-setup-gitops.yml
+```bash
+task 50-gitops
+# or directly:
+uv run ansible-playbook 50-gitops.yml
 ```
 
-Deploys ArgoCD via Helm and applies the App-of-Apps root app.
+What the playbook does, in order:
+
+1. Verifies the cluster is ready (pi0 node must be in `Ready` state)
+2. Adds the `argo` Helm repository (`https://argoproj.github.io/argo-helm`)
+3. Installs or upgrades ArgoCD via Helm:
+   - Chart: `argo/argo-cd` version `9.5.15` (pinned in `ansible/group_vars/all.yml`)
+   - Namespace: `argocd` (created if absent)
+   - Values: `ansible/roles/gitops/files/argocd-helm-values.yaml`
+4. Waits for `argocd-server` Deployment to reach `Available`
+5. Creates (or updates) the `root-app` Application manifest in the `argocd` namespace
+
+After the playbook completes, ArgoCD picks up `homekube-apps/applications/` and begins syncing all child Applications.
 
 ---
 
 ## App-of-Apps Structure
 
-### Init Wave (`sync-wave: "-1"`)
+### Wave 00 — Init (`sync-wave: "-1"`)
 
-- [argocd-config](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/argocd-config.yaml)
-- [longhorn](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/longhorn.yaml)
-- [metrics-server](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/metrics-server.yaml)
+Deploys infrastructure dependencies that must be ready before application workloads:
 
-### Apps Wave (`sync-wave: "1"`)
+| Application | Namespace | Purpose |
+|-------------|-----------|---------|
+| [argocd-config](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/argocd-config.yaml) | argocd | ArgoCD RBAC / ConfigMap overrides |
+| [longhorn](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/longhorn.yaml) | longhorn-system | Distributed block storage |
+| [metrics-server](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/metrics-server.yaml) | kube-system | `kubectl top` / HPA metrics |
 
-(TBD)
+### Wave 01 — Apps (`sync-wave: "1"`)
+
+Deploys workloads after wave-00 storage and metrics are ready:
+
+| Application | Namespace | Purpose |
+|-------------|-----------|---------|
+| kube-prometheus | observability | Prometheus + Grafana + Alertmanager (kube-prometheus-stack) |
+| loki | observability | Log aggregation |
+| alloy | observability | Metrics and log collector (Grafana Alloy) |
+
+> These Application files live under `homekube-apps/applications/wave-01-apps/`.
+
+---
+
+## Sync Policy
+
+The root app is created with:
+
+```yaml
+syncPolicy:
+  automated:
+    prune: true
+    selfHeal: true
+```
+
+- **Automated**: ArgoCD polls and syncs without manual approval
+- **Prune**: resources removed from Git are deleted from the cluster
+- **Self-heal**: out-of-band changes to cluster state are reverted on the next sync
+
+Child Applications inherit their own sync policies from their respective YAML files in `homekube-apps`.
+
+---
+
+## Access
+
+### Admin password (first login)
+
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret \
+  -o jsonpath="{.data.password}" | base64 -d
+```
+
+Username: `admin`
+
+### UI (port-forward)
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+Then open `https://localhost:8080` (accept the self-signed cert).
+
+### OIDC
+
+ArgoCD is configured for Google OIDC via an external Dex instance at
+`https://pi0.taild13083.ts.net/dex`. RBAC policy:
+
+| Identity | Role |
+|----------|------|
+| `jan.groth.de@gmail.com` | `role:admin` |
+| `homepage` (API key) | `role:readonly` |
+
+The `homepage` account is used by the Homepage dashboard widget (spec 007) with an API key — no password login.
+
+---
+
+## Configuration
+
+| File | Purpose |
+|------|---------|
+| `ansible/roles/gitops/files/argocd-helm-values.yaml` | ArgoCD Helm values (replicas, OIDC, RBAC, metrics) |
+| `ansible/group_vars/all.yml` | Pinned `argocd_helm_chart_version`, root app repo URL and path |
+| `https://github.com/jangroth/homekube-apps` | All Application manifests and Helm values |
+
+---
+
+## Day-2 Operations
+
+### Upgrade ArgoCD
+
+Bump `argocd_helm_chart_version` in `ansible/group_vars/all.yml`, then re-run `task 50-gitops`. The playbook is idempotent — it upgrades if ArgoCD is already installed.
+
+### Check sync status
+
+```bash
+kubectl get applications -n argocd
+# or via CLI:
+argocd app list   # requires argocd CLI and login
+```
+
+### Force a sync
+
+```bash
+kubectl -n argocd patch application <name> \
+  --type merge -p '{"operation":{"sync":{}}}'
+```
+
+### Verify root-app is watching the correct repo
+
+```bash
+kubectl -n argocd get application root-app -o jsonpath='{.spec.source}'
+```
+
+Expected output: `repoURL: https://github.com/jangroth/homekube-apps.git`, `path: applications`.
+
+---
+
+## Status
+
+| Step | State |
+|------|-------|
+| ArgoCD installed (Helm chart 9.5.15) | done |
+| root-app created and syncing | done |
+| wave-00-init (longhorn, metrics-server, argocd-config) | done |
+| wave-01-apps (observability stack) | done |

--- a/docs/05_gitops.md
+++ b/docs/05_gitops.md
@@ -8,14 +8,13 @@ Run from `homekube-main/ansible/` on darth.
 
 ## Overview
 
-The cluster uses ArgoCD's **App-of-Apps** pattern: a single root Application (`root-app`) in the `argocd` namespace watches the `jangroth/homekube-apps` Git repository. Every subdirectory under `applications/` is itself an ArgoCD Application — ArgoCD discovers and deploys them automatically. Changes pushed to `homekube-apps` are synced continuously; no manual `kubectl apply` is needed after initial bootstrap.
+The cluster uses ArgoCD's **App-of-Apps** pattern: a single root Application (`root-app`) in the `argocd` namespace watches the `jangroth/homekube-apps` Git repository. `applications/kustomization.yaml` explicitly lists every child Application manifest as a Kustomize resource — root-app builds that file, and ArgoCD deploys whatever it resolves to. Adding a new app means adding it to `kustomization.yaml`, not just dropping a file in a subdirectory. Changes pushed to `homekube-apps` are synced continuously; no manual `kubectl apply` is needed after initial bootstrap.
 
 ```
 homekube-main (Ansible bootstrap)
   └── root-app (ArgoCD Application)
-        └── homekube-apps/applications/
-              ├── wave-00-init/   (sync-wave: "-1")
-              └── wave-01-apps/   (sync-wave: "1")
+        └── homekube-apps/applications/  (kustomization.yaml)
+              └── wave-NN-<name>/   (argocd.argoproj.io/sync-wave: "<N>")
 ```
 
 ---
@@ -45,27 +44,9 @@ After the playbook completes, ArgoCD picks up `homekube-apps/applications/` and 
 
 ## App-of-Apps Structure
 
-### Wave 00 — Init (`sync-wave: "-1"`)
+Applications are grouped into `wave-NN-<name>/` directories under `homekube-apps/applications/`, each carrying an `argocd.argoproj.io/sync-wave` annotation. Lower-numbered waves deploy first (cluster-level infra: storage, networking, cert management); higher waves deploy application and observability workloads that depend on earlier waves being healthy.
 
-Deploys infrastructure dependencies that must be ready before application workloads:
-
-| Application | Namespace | Purpose |
-|-------------|-----------|---------|
-| [argocd-config](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/argocd-config.yaml) | argocd | ArgoCD RBAC / ConfigMap overrides |
-| [longhorn](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/longhorn.yaml) | longhorn-system | Distributed block storage |
-| [metrics-server](https://github.com/jangroth/homekube-apps/blob/main/applications/wave-00-init/metrics-server.yaml) | kube-system | `kubectl top` / HPA metrics |
-
-### Wave 01 — Apps (`sync-wave: "1"`)
-
-Deploys workloads after wave-00 storage and metrics are ready:
-
-| Application | Namespace | Purpose |
-|-------------|-----------|---------|
-| kube-prometheus | observability | Prometheus + Grafana + Alertmanager (kube-prometheus-stack) |
-| loki | observability | Log aggregation |
-| alloy | observability | Metrics and log collector (Grafana Alloy) |
-
-> These Application files live under `homekube-apps/applications/wave-01-apps/`.
+The current set of waves and applications lives entirely in [`homekube-apps/applications/`](https://github.com/jangroth/homekube-apps/tree/main/applications) — not duplicated here, since it changes independently of this doc.
 
 ---
 
@@ -160,13 +141,3 @@ kubectl -n argocd get application root-app -o jsonpath='{.spec.source}'
 
 Expected output: `repoURL: https://github.com/jangroth/homekube-apps.git`, `path: applications`.
 
----
-
-## Status
-
-| Step | State |
-|------|-------|
-| ArgoCD installed (Helm chart 9.5.15) | done |
-| root-app created and syncing | done |
-| wave-00-init (longhorn, metrics-server, argocd-config) | done |
-| wave-01-apps (observability stack) | done |


### PR DESCRIPTION
## Summary

Replaces the 25-line stub in `docs/05_gitops.md` with a complete operational guide covering the GitOps layer as actually deployed.

**What's documented:**

- ArgoCD App-of-Apps pattern overview (root-app → homekube-apps/applications)
- What `task 50-gitops` / `50-gitops.yml` does step by step
- Wave structure: wave-00-init (argocd-config, longhorn, metrics-server) and wave-01-apps (kube-prometheus, loki, alloy)
- Sync policy (automated, prune, selfHeal)
- Access: admin password retrieval command and UI port-forward
- OIDC/RBAC configuration (Google OIDC, admin and homepage accounts)
- Configuration file reference table
- Day-2 operations: upgrade, status check, force sync, verify root-app

All facts sourced from `ansible/roles/gitops/` tasks and values files, and `ansible/group_vars/all.yml`.

## Notes for review

- The wave-01-apps table (kube-prometheus, loki, alloy) is inferred from references in open issues rather than reading the `homekube-apps` repo directly — please correct any app names or namespaces that don't match the live Applications.
- Dex is noted as external (`pi0.taild13083.ts.net/dex`) since `dex.enabled: false` in the Helm values.

Closes jangroth/homekube#33

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJKFnczEZ3at4fJiAcGJto)_