### PR TITLE
Resolve ansible-lint basic profile violations

### DIFF
--- a/ansible/10-nvme.yml
+++ b/ansible/10-nvme.yml
@@ -3,7 +3,8 @@
 #   Phase 1 (pre-attach):  ansible-playbook setup-nvme.yml --tags nvme_pre
 #   Phase 2 (post-attach): ansible-playbook setup-nvme.yml --tags nvme_post --limit pi0,pi1,pi2
 # See docs/specs/001-nvme-clone-automation.md.
-- hosts: all_nodes
+- name: NVMe migration
+  hosts: all_nodes
   become: true
   serial: 1
   gather_facts: false

--- a/ansible/20-configure-darth.yml
+++ b/ansible/20-configure-darth.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Configure control node (darth)
+  hosts: localhost
   connection: local
   gather_facts: false
   roles:

--- a/ansible/21-provision-pis.yml
+++ b/ansible/21-provision-pis.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: [all_nodes]
+- name: Provision Raspberry Pis
+  hosts: [all_nodes]
   gather_facts: false
   become: true
   roles:

--- a/ansible/22-k8s-nodes.yml
+++ b/ansible/22-k8s-nodes.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: [all_nodes]
+- name: Configure k8s prerequisites on all nodes
+  hosts: [all_nodes]
   become: true
   roles:
     - role: k8s-node

--- a/ansible/30-k8s-control-plane.yml
+++ b/ansible/30-k8s-control-plane.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: [control_plane]
+- name: Initialize k8s control plane
+  hosts: [control_plane]
   become: true
   roles:
     - role: k8s-control-plane

--- a/ansible/31-k8s-workers.yml
+++ b/ansible/31-k8s-workers.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: data_plane
+- name: Join k8s worker nodes
+  hosts: data_plane
   become: true
   roles:
     - role: k8s-worker

--- a/ansible/50-gitops.yml
+++ b/ansible/50-gitops.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: [control_plane]
+- name: Install GitOps (ArgoCD)
+  hosts: [control_plane]
   become: false
   roles:
     - role: gitops

--- a/ansible/roles/control-node/tasks/main.yml
+++ b/ansible/roles/control-node/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
-- import_tasks: update_known-hosts.yml
-- import_tasks: update_ssh_config.yml
-- import_tasks: install_packages.yml
+- name: Update known hosts
+  import_tasks: update_known-hosts.yml
+- name: Update SSH config
+  import_tasks: update_ssh_config.yml
+- name: Install packages
+  import_tasks: install_packages.yml
   tags: update-only
-- import_tasks: trust_homekube_ca.yml
+- name: Trust homekube CA
+  import_tasks: trust_homekube_ca.yml

--- a/ansible/roles/k8s-control-plane/tasks/install_kube_bench.yml
+++ b/ansible/roles/k8s-control-plane/tasks/install_kube_bench.yml
@@ -20,7 +20,8 @@
     var: installed_kube_bench_version
 
 # Only proceed with kube-bench installation/update if version differs
-- when: installed_kube_bench_version != kube_bench_version
+- name: Install or update kube-bench
+  when: installed_kube_bench_version != kube_bench_version
 
   block:
     - name: Check if kube-bench already downloaded

--- a/ansible/roles/k8s-control-plane/tasks/main.yml
+++ b/ansible/roles/k8s-control-plane/tasks/main.yml
@@ -1,9 +1,13 @@
 ---
-- import_tasks: copy_config_files.yml
+- name: Copy config files
+  import_tasks: copy_config_files.yml
   tags: update-only
 
-- import_tasks: init_control_plane.yml
+- name: Initialize control plane
+  import_tasks: init_control_plane.yml
 
-- import_tasks: setup_kubeconfig.yml
+- name: Set up kubeconfig
+  import_tasks: setup_kubeconfig.yml
 
-- import_tasks: install_kube_bench.yml
+- name: Install kube-bench
+  import_tasks: install_kube_bench.yml

--- a/ansible/roles/k8s-node/tasks/install_container_runtime.yml
+++ b/ansible/roles/k8s-node/tasks/install_container_runtime.yml
@@ -38,7 +38,8 @@
     var: installed_containerd_version
 
 # Only proceed with containerd installation/update if version differs
-- when: installed_containerd_version != containerd_version
+- name: Install or update containerd
+  when: installed_containerd_version != containerd_version
 
   block:
     - name: Check if containerd already downloaded

--- a/ansible/roles/k8s-node/tasks/install_etcdctl.yml
+++ b/ansible/roles/k8s-node/tasks/install_etcdctl.yml
@@ -23,7 +23,8 @@
     var: installed_etcdctl_version
 
 # Only proceed with etcdctl installation/update if version differs
-- when: installed_etcdctl_version != etcdctl_version
+- name: Install or update etcdctl
+  when: installed_etcdctl_version != etcdctl_version
 
   block:
     - name: Check if etcdctl already downloaded

--- a/ansible/roles/k8s-node/tasks/install_tailscale.yml
+++ b/ansible/roles/k8s-node/tasks/install_tailscale.yml
@@ -1,15 +1,15 @@
 ---
 - name: Add Tailscale's package signing key
-  shell: |
-    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
-  args:
-    creates: /usr/share/keyrings/tailscale-archive-keyring.gpg
+  ansible.builtin.get_url:
+    url: https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg
+    dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
+    mode: "0644"
 
 - name: Add Tailscale repository
-  shell: |
-    curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
-  args:
-    creates: /etc/apt/sources.list.d/tailscale.list
+  ansible.builtin.get_url:
+    url: https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list
+    dest: /etc/apt/sources.list.d/tailscale.list
+    mode: "0644"
 
 - name: Update apt cache
   apt:

--- a/ansible/roles/k8s-node/tasks/main.yml
+++ b/ansible/roles/k8s-node/tasks/main.yml
@@ -1,25 +1,41 @@
 ---
-- import_tasks: update_system.yml
+- name: Update system
+  import_tasks: update_system.yml
   tags: update-only
-- import_tasks: configure_kernel.yml
+- name: Configure kernel
+  import_tasks: configure_kernel.yml
   tags: update-only
-- import_tasks: configure_networking.yml
-- import_tasks: configure_etc_hosts.yml
-- import_tasks: reload_networking_modules.yml
+- name: Configure networking
+  import_tasks: configure_networking.yml
+- name: Configure /etc/hosts
+  import_tasks: configure_etc_hosts.yml
+- name: Reload networking modules
+  import_tasks: reload_networking_modules.yml
   tags: update-only
-- import_tasks: configure_cgroups.yml
-- import_tasks: configure_storage.yml
+- name: Configure cgroups
+  import_tasks: configure_cgroups.yml
+- name: Configure storage
+  import_tasks: configure_storage.yml
   tags: update-only
-- import_tasks: install_container_runtime.yml
-- import_tasks: unhold_kube_packages.yml
+- name: Install container runtime
+  import_tasks: install_container_runtime.yml
+- name: Unhold kube packages
+  import_tasks: unhold_kube_packages.yml
   tags: unhold-kube
   when: "'unhold-kube' in ansible_run_tags"
-- import_tasks: install_kube_packages.yml
-- import_tasks: configure_swap.yml
-- import_tasks: configure_kubernetes_dns.yml
-- import_tasks: configure_kubelet_node_ip.yml
-- import_tasks: install_etcdctl.yml
+- name: Install kube packages
+  import_tasks: install_kube_packages.yml
+- name: Configure swap
+  import_tasks: configure_swap.yml
+- name: Configure Kubernetes DNS
+  import_tasks: configure_kubernetes_dns.yml
+- name: Configure kubelet node IP
+  import_tasks: configure_kubelet_node_ip.yml
+- name: Install etcdctl
+  import_tasks: install_etcdctl.yml
   tags: update-only
-- import_tasks: configure_tailscale_subnet.yml
-- import_tasks: display_dependencies.yml
+- name: Configure Tailscale subnet
+  import_tasks: configure_tailscale_subnet.yml
+- name: Display dependencies
+  import_tasks: display_dependencies.yml
   tags: update-only

--- a/ansible/roles/k8s-node/tasks/reload_networking_modules.yml
+++ b/ansible/roles/k8s-node/tasks/reload_networking_modules.yml
@@ -1,6 +1,7 @@
 ---
 # this works around a problem where raspberry pi unloads networking modules and CNI funcionality breaks
 - name: Run tcpdump network diagnostics on wlan0
-  shell: sudo tcpdump -i wlan0 -c2
+  command: tcpdump -i wlan0 -c2
   register: tcpdump_output
   ignore_errors: true
+  changed_when: false

--- a/ansible/roles/k8s-node/tasks/update_system.yml
+++ b/ansible/roles/k8s-node/tasks/update_system.yml
@@ -5,10 +5,17 @@
     state: directory
     mode: "0755"
 
-- name: Add Kubernetes apt repository key
-  ansible.builtin.shell:
-    cmd: curl -fsSL https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version.split('.')[:2] | join('.') }}/deb/Release.key | gpg --batch --yes --dearmor -o
-      /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+- name: Download Kubernetes apt repository key
+  ansible.builtin.get_url:
+    url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version.split('.')[:2] | join('.') }}/deb/Release.key"
+    dest: /tmp/kubernetes-apt-keyring.asc
+    mode: "0644"
+    force: true
+  become: true
+
+- name: Dearmor Kubernetes apt repository key
+  ansible.builtin.command:
+    cmd: gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg /tmp/kubernetes-apt-keyring.asc
   become: true
   changed_when: false
 

--- a/ansible/roles/k8s-worker/tasks/main.yml
+++ b/ansible/roles/k8s-worker/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
-- import_tasks: query_join_credentials.yml
+- name: Query join credentials
+  import_tasks: query_join_credentials.yml
 
-- import_tasks: join_cluster.yml
+- name: Join cluster
+  import_tasks: join_cluster.yml

--- a/ansible/roles/raspberry-pi/tasks/copy_mmc_to_nvme.yml
+++ b/ansible/roles/raspberry-pi/tasks/copy_mmc_to_nvme.yml
@@ -181,12 +181,29 @@
 # ---------- Rsync ----------
 
 - name: Rsync / → /mnt/clone (long-running)
-  command: rsync -axH --delete --exclude=/mnt / /mnt/clone/
+  ansible.posix.synchronize:
+    src: /
+    dest: /mnt/clone/
+    archive: true
+    delete: true
+    rsync_opts:
+      - "--one-file-system"
+      - "--hard-links"
+      - "--exclude=/mnt"
+  delegate_to: "{{ inventory_hostname }}"
   register: rsync_root
   changed_when: rsync_root.stdout_lines | length > 0
 
 - name: Rsync /boot/firmware → /mnt/clone/boot/firmware
-  command: rsync -axH --delete /boot/firmware/ /mnt/clone/boot/firmware/
+  ansible.posix.synchronize:
+    src: /boot/firmware/
+    dest: /mnt/clone/boot/firmware/
+    archive: true
+    delete: true
+    rsync_opts:
+      - "--one-file-system"
+      - "--hard-links"
+  delegate_to: "{{ inventory_hostname }}"
   register: rsync_boot
   changed_when: rsync_boot.stdout_lines | length > 0
 

--- a/ansible/roles/raspberry-pi/tasks/main.yml
+++ b/ansible/roles/raspberry-pi/tasks/main.yml
@@ -1,18 +1,25 @@
 ---
-- import_tasks: create_user_account.yml
+- name: Create user account
+  import_tasks: create_user_account.yml
   tags: init
   when: "'init' in ansible_run_tags"
-- import_tasks: update_system.yml
+- name: Update system
+  import_tasks: update_system.yml
   tags: init
   when: "'init' in ansible_run_tags"
-- import_tasks: disable_password_auth.yml
+- name: Disable password auth
+  import_tasks: disable_password_auth.yml
   tags: init
   when: "'init' in ansible_run_tags"
-- import_tasks: enable_pciex.yml
+- name: Enable PCIe
+  import_tasks: enable_pciex.yml
   tags: nvme_pre
   when: "'nvme_pre' in ansible_run_tags"
-- import_tasks: copy_mmc_to_nvme.yml
+- name: Copy MMC to NVMe
+  import_tasks: copy_mmc_to_nvme.yml
   tags: nvme_post
   when: "'nvme_post' in ansible_run_tags"
-- import_tasks: sync_authorized_keys.yml
-- import_tasks: verify_sshd_config.yml
+- name: Sync authorized keys
+  import_tasks: sync_authorized_keys.yml
+- name: Verify sshd config
+  import_tasks: verify_sshd_config.yml


### PR DESCRIPTION
## Summary

Resolves the remaining `ansible-lint` basic-profile violations tracked in jangroth/homekube#36. Reduces fatal violations from 59 → 5 (the 5 remaining are `syntax-check[unknown-module]` caused by Galaxy collections not being installed in the lint environment — pre-existing, not introduced here, and unskippable via config).

### Changes by category

**`name[play]` (7 fixes)** — Added `name:` to all unnamed top-level plays:
- `10-nvme.yml`, `20-configure-darth.yml`, `21-provision-pis.yml`, `22-k8s-nodes.yml`, `30-k8s-control-plane.yml`, `31-k8s-workers.yml`, `50-gitops.yml`

**`name[missing]` (36 fixes)** — Added `name:` to all unnamed `import_tasks` entries in the five role `main.yml` files (`control-node`, `k8s-control-plane`, `k8s-node`, `k8s-worker`, `raspberry-pi`) and to the three unnamed `block:` containers in `install_kube_bench.yml`, `install_container_runtime.yml`, `install_etcdctl.yml`.

**`command-instead-of-module` (5 fixes)**:
- `install_tailscale.yml`: replaced two `shell: | curl … | tee` tasks with `ansible.builtin.get_url`
- `update_system.yml`: split the `curl … | gpg --dearmor` pipeline into a `get_url` download step followed by a `command: gpg --dearmor` step
- `copy_mmc_to_nvme.yml`: replaced both `command: rsync -axH` tasks with `ansible.posix.synchronize` (collection already in `requirements.yml`)

**`command-instead-of-shell` (1 fix)**:
- `reload_networking_modules.yml`: `shell: sudo tcpdump -i wlan0 -c2` → `command: tcpdump -i wlan0 -c2` (no shell features required; `sudo` is redundant with `become: true`)

## Sanity checks

- All 19 changed files pass `python3 -c "yaml.safe_load_all(…)"` YAML validation
- `ansible-lint ansible/ --profile basic` confirmed: 59 → 5 remaining violations (all `syntax-check[unknown-module]`, pre-existing)
- No playbooks were run against live hosts

Closes jangroth/homekube#36

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwtqTp5xsrvJ2uGXNA4ABc)_