### PR TITLE
Add resource requests/limits to ArgoCD components

### DIFF
--- a/ansible/roles/gitops/files/argocd-helm-values.yaml
+++ b/ansible/roles/gitops/files/argocd-helm-values.yaml
@@ -3,6 +3,13 @@
 
 applicationSet:
   replicaCount: 1
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
 configs:
   cm:
     create: true
@@ -44,16 +51,67 @@ controller:
   replicas: 1
   metrics:
     enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
 dex:
   enabled: false
+notifications:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 redis:
   exporter:
     enabled: true
+    resources:
+      requests:
+        cpu: 5m
+        memory: 16Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
   metrics:
     enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 repoServer:
   replicas: 1
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  copyutil:
+    resources:
+      requests:
+        cpu: 5m
+        memory: 16Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
 server:
   replicas: 1
   metrics:
     enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi


### PR DESCRIPTION
## Summary

Sets CPU and memory `requests`/`limits` for all eight ArgoCD containers in `ansible/roles/gitops/files/argocd-helm-values.yaml`:

| Component | Helm key | CPU request/limit | Memory request/limit |
|---|---|---|---|
| application-controller | `controller.resources` | 100m / 500m | 128Mi / 512Mi |
| applicationset-controller | `applicationSet.resources` | 25m / 200m | 64Mi / 256Mi |
| notifications-controller | `notifications.resources` | 10m / 100m | 32Mi / 128Mi |
| redis | `redis.resources` | 25m / 200m | 32Mi / 128Mi |
| redis-metrics (exporter) | `redis.exporter.resources` | 5m / 50m | 16Mi / 64Mi |
| repo-server | `repoServer.resources` | 25m / 200m | 64Mi / 256Mi |
| copyutil (init container) | `repoServer.copyutil.resources` | 5m / 50m | 16Mi / 64Mi |
| server | `server.resources` | 25m / 200m | 64Mi / 256Mi |

Baselines are conservative estimates appropriate for a Raspberry Pi 4 homelab cluster, with headroom above typical idle usage. Applied via `task 50-gitops` (Helm upgrade of `argo/argo-cd` chart v9.5.15).

## Sanity checks

- `python3 -c "yaml.safe_load(...)"` — YAML valid, no duplicate keys
- All 8 resource sections verified present with both `requests` and `limits`
- `ansible-playbook --syntax-check 50-gitops.yml` — blocked only by Galaxy collections absent in the lint environment (pre-existing, same as PR #7); no new errors introduced
- No playbooks run against live hosts

Closes jangroth/homekube#6


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tfh2Rn63sN3yuR6jQusdLW)_