### PR TITLE
Add resource requests/limits to Cilium and Hubble components

### DIFF
--- a/ansible/roles/cni/files/cilium-helm-values.yaml
+++ b/ansible/roles/cni/files/cilium-helm-values.yaml
@@ -23,9 +23,63 @@ k8sClientRateLimit:
   qps: 50
   burst: 100
 
+# Cilium agent DaemonSet (covers main container and init containers:
+# config, mount-cgroup, apply-sysctl-overwrites, mount-bpf-fs, clean-cilium-state).
+# Baselines are conservative estimates for Raspberry Pi 4 nodes.
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# Cilium Envoy proxy DaemonSet (L7 policy enforcement).
+envoy:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
+
+# Cilium Operator Deployment (cluster-scoped controller).
+operator:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
 hubble:
   enabled: true
   relay:
     enabled: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
   ui:
     enabled: true
+    frontend:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 16Mi
+        limits:
+          cpu: 50m
+          memory: 64Mi
+    backend:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 32Mi
+        limits:
+          cpu: 50m
+          memory: 128Mi


### PR DESCRIPTION
## Summary

Sets CPU and memory `requests`/`limits` for all Cilium and Hubble containers in `ansible/roles/cni/files/cilium-helm-values.yaml`:

| Component | Helm key | CPU request/limit | Memory request/limit |
|---|---|---|---|
| cilium agent (+ init containers) | `resources` | 100m / 500m | 128Mi / 512Mi |
| cilium-envoy | `envoy.resources` | 25m / 300m | 64Mi / 256Mi |
| cilium-operator | `operator.resources` | 25m / 200m | 64Mi / 256Mi |
| hubble-relay | `hubble.relay.resources` | 10m / 100m | 32Mi / 128Mi |
| hubble-ui frontend | `hubble.ui.frontend.resources` | 5m / 50m | 16Mi / 64Mi |
| hubble-ui backend | `hubble.ui.backend.resources` | 5m / 50m | 32Mi / 128Mi |

Baselines are conservative estimates appropriate for a Raspberry Pi 4 homelab cluster, with headroom above typical idle usage. Applied via `task 40-cni` (Helm upgrade of `cilium/cilium` chart v1.19.4).

## Sanity checks

- `python3 -c "yaml.safe_load(...)"` — YAML valid, no duplicate keys
- All 6 resource sections verified present with both `requests` and `limits`
- `ansible-playbook --syntax-check 40-cni.yml` — blocked only by Galaxy collections absent in the lint environment (pre-existing, same as PRs #7 and #8); no new errors introduced
- No playbooks run against live hosts

Closes jangroth/homekube#5

---
_Generated by [Claude Code](https://claude.ai/code/session_015dZiQJcSuq9sPgYLJkqFbt)_